### PR TITLE
Add command to rtorrent service

### DIFF
--- a/overlay/usr/local/etc/rc.d/rtorrent
+++ b/overlay/usr/local/etc/rc.d/rtorrent
@@ -12,6 +12,7 @@ rcvar="rtorrent_enable"
 
 start_cmd="${name}_start"
 stop_cmd="${name}_stop"
+command="/usr/local/bin/rtorrent"
 
 rtorrent_start() {
 	su - rtorrent -c "tmux new-session -d -s rtorrent 'nice /usr/local/bin/rtorrent'"


### PR DESCRIPTION
Add missing `command` to `rtorrent` service file in order to solve not supported `status` command. See test run: https://cirrus-ci.com/task/5593115022065664?command=install#L909